### PR TITLE
docs: script format bit misspell README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,12 +154,12 @@ For HowTo100M, the features should be stored in `HOWTO_FEATURES_PATH`, one file 
     
 This requires downloading the pretrained BRNN model weights from [Punctuator2](https://github.com/ottokart/punctuator2). The `INTERSPEECH-T-BRNN.pcl` file should be in `DEFAULT_MODEL_DIR`. 
 
-**Punctuating**: First, we punctuate the speech data at the video level and split the video into clips temporally aligned with infered sentences (you may launch this script on multiple CPUs to fasten the process):
+**Punctuating**: First, we punctuate the speech data at the video level and split the video into clips temporally aligned with inferred sentences (you may launch this script on multiple CPUs to fasten the process):
 ```
 python videoqa_generation/punctuate.py
 ```
 
-**Merging infered speech sentences**: Second, we merge the punctuated data into one file:
+**Merging inferred speech sentences**: Second, we merge the punctuated data into one file:
 ```
 python videoqa_generation/merge_punctuations.py
 ```
@@ -223,6 +223,7 @@ If you wish to train a VideoQA model on Web videos.
 <details>
 <summary>Click for details... </summary>
 To train on HowToVQA69M with contrastive loss and MLM loss (it takes less than 48H on 8 NVIDIA Tesla V100), run:
+
 ```
 python main_howtovqa.py --dataset="howtovqa" --epochs=10 --checkpoint_dir="pthowtovqa" \
 --batch_size=128 --batch_size_val=256 --n_pair=32 --freq_display=10
@@ -234,7 +235,8 @@ Also note that DistilBERT tokenizer and model checkpoints will be automatically 
 **Training VQA-T on WebVidVQA3M**:
 <details>
 <summary>Click for details... </summary>
-To train on WebVidVQA3M with contrastive loss and MLM loss (it takes less than 3H on 8 NVIDIA Tesla V100),
+To train on WebVidVQA3M with contrastive loss and MLM loss (it takes less than 3H on 8 NVIDIA Tesla V100), run:
+
 ```
 python main_howtovqa.py --dataset="webvidvqa" --epochs=10 --checkpoint_dir="ptwebvidvqa" \
 --batch_size=4096 --batch_size_val=8192 --freq_display=10

--- a/README.md
+++ b/README.md
@@ -222,8 +222,8 @@ If you wish to train a VideoQA model on Web videos.
 **Training VQA-T on HowToVQA69M**:
 <details>
 <summary>Click for details... </summary>
-To train on HowToVQA69M with contrastive loss and MLM loss (it takes less than 48H on 8 NVIDIA Tesla V100), run:
 
+To train on HowToVQA69M with contrastive loss and MLM loss (it takes less than 48H on 8 NVIDIA Tesla V100), run:
 ```
 python main_howtovqa.py --dataset="howtovqa" --epochs=10 --checkpoint_dir="pthowtovqa" \
 --batch_size=128 --batch_size_val=256 --n_pair=32 --freq_display=10
@@ -235,8 +235,8 @@ Also note that DistilBERT tokenizer and model checkpoints will be automatically 
 **Training VQA-T on WebVidVQA3M**:
 <details>
 <summary>Click for details... </summary>
-To train on WebVidVQA3M with contrastive loss and MLM loss (it takes less than 3H on 8 NVIDIA Tesla V100), run:
 
+To train on WebVidVQA3M with contrastive loss and MLM loss (it takes less than 3H on 8 NVIDIA Tesla V100), run:
 ```
 python main_howtovqa.py --dataset="webvidvqa" --epochs=10 --checkpoint_dir="ptwebvidvqa" \
 --batch_size=4096 --batch_size_val=8192 --freq_display=10


### PR DESCRIPTION
Enabling code formatting as of example in the screenshot.
![After](https://github.com/antoyang/just-ask/assets/36249910/eb8d2bd3-0f96-4e68-b70e-5809a2ceacb5)